### PR TITLE
Email subsampling and changes in preprocessing logic

### DIFF
--- a/code/dal.py
+++ b/code/dal.py
@@ -139,7 +139,13 @@ def __clean_data_glove(data):
     for idx in data.shape[0]:
         # Cannot be vectorized as ndarrays are not contiguous
         # TODO: See if we can refactor logic to avoid numpy arrays
-        data[idx, 3] = clean_mail(data[idx, 3])
+        cleaned_mail_thread = clean_mail(data[idx, 3])
+        
+        # Truncate the email after the first mail in the thread
+        end_of_thread = cleaned_mail_thread.find('original message')
+        end_of_thread = len(cleaned_mail_thread) if end_of_thread == -1 else end_of_thread
+        cleaned_mail = cleaned_mail_thread[:end_of_thread]
+        data[idx, 3] = cleaned_mail
 
     return data
 

--- a/code/main.py
+++ b/code/main.py
@@ -21,13 +21,13 @@ if __name__ == '__main__':
     utils.populate_userid_mapping()
     NUM_EMAILS = 200
 
-    #model = Model1(epochs=10)
+    # model = Model1(epochs=10)
     # model = Model2()
     model = Model3(epochs=3)
     # w2v = W2VCustom()
     w2v = W2VGlove()
 
-    emails = dal.get_emails(NUM_EMAILS)
+    emails = dal.get_emails(NUM_EMAILS, max_users=10, fetch_all=False)
     w2v.train(emails)
 
     email_body = emails[0][2]


### PR DESCRIPTION
1. `dal.get_emails` now has an additional parameter called `max_users` which lets us run the model on a subset of data filtered by user instead of arbitrarily picked the first N emails
2. A new function `__clean_data_glove` has been added to tokenize the words based on the format followed by GloVe embeddings. This requires a dependency that has been pushed as a resource.
3. It was noticed that additional mails in an email thread, contrary to our understanding, had not been removed which led to extremely long email bodies.

Changes 1 and 3 should improve the training process considerably as there will be less number of mails (faster training) which are more relevant (better performance) as well.

Future enhancement: Change 3 could be refactored to work with w2v custom and the previous `__clean_data` implementation as well